### PR TITLE
Fix issue that is caused when Lithium is enabled and add orderBy to HasMany{,Through}

### DIFF
--- a/krypton/Model.js
+++ b/krypton/Model.js
@@ -82,7 +82,6 @@ Krypton.Model = Class(Krypton, 'Model').includes(Krypton.ValidationSupport)({
   },
 
   _loadRelations : function(knex) {
-
     var relations = this.relations;
 
     var result = {};

--- a/krypton/Relation.js
+++ b/krypton/Relation.js
@@ -22,7 +22,7 @@ Krypton.Relation = Class(Krypton, 'Relation')({
         throw new Error('Must provide an ownerModel');
       }
 
-      if (config.ownerModel.superClass !== Krypton.Model) {
+      if (config.ownerModel.superClass.className !== Krypton.Model.className) {
         throw new Error('ownerModel is not a subclass of Krypton.Model');
       }
 
@@ -30,7 +30,7 @@ Krypton.Relation = Class(Krypton, 'Relation')({
         throw new Error('Must provide a relatedModel');
       }
 
-      if (config.relatedModel.superClass !== Krypton.Model) {
+      if (config.relatedModel.superClass.className !== Krypton.Model.className) {
         throw new Error('relatedModel is not a subclass of Krypton.Model');
       }
 

--- a/krypton/relations/HasMany.js
+++ b/krypton/relations/HasMany.js
@@ -17,6 +17,10 @@ Krypton.Relation.HasMany = Class(Krypton.Relation, 'HasMany').inherits(Krypton.R
         query.andWhere.apply(query, relation.scope);
       }
 
+      if (relation.orderBy) {
+        query.orderBy.apply(query, relation.orderBy);
+      }
+
       return query.then(function(result) {
         records.forEach(function(record) {
           var asoc = result.filter(function(item) {

--- a/krypton/relations/HasManyThrough.js
+++ b/krypton/relations/HasManyThrough.js
@@ -23,6 +23,10 @@ Krypton.Relation.HasManyThrough = Class(Krypton.Relation, 'HasManyThrough').inhe
           query.andWhere.apply(query, relation.scope);
         }
 
+        if (relation.orderBy) {
+          query.orderBy.apply(query, relation.orderBy);
+        }
+
         return query
           .then(function(results) {
             record[relation.name] = results;


### PR DESCRIPTION
Lithium adds its spies to objects and classes, this causes issues when you are comparing two objects because you cannot be sure that they'll be the same.

This commit changes a conditional in `Relation.js` so that it uses `.className` to compare instead of comparing two objects with each other.