### PR TITLE
Remove expectations for Krypton.Relation models to be Krypton models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2016-03-15, Version 0.0.13
+- Fixed a typo in Model.destroy()
+
 ## 2016-02-22, Version 0.0.12
 - Add {after, before} destroy hooks
 - Improve Invalid Hook Error Message

--- a/krypton/Model.js
+++ b/krypton/Model.js
@@ -372,7 +372,7 @@ Krypton.Model = Class(Krypton, 'Model').includes(Krypton.ValidationSupport)({
             var knex;
 
             if (model._knex) {
-              knex = model._knex.table(this.constructor.tableName);
+              knex = model._knex.table(model.constructor.tableName);
             } else {
               knex = model.constructor.knexQuery();
             }

--- a/krypton/Relation.js
+++ b/krypton/Relation.js
@@ -1,5 +1,24 @@
 var _ = require('lodash');
 
+var loopThroughSuper = function (model) {
+  var currentModel = model;
+  var superName = Krypton.Model.className;
+  var isSubclass = false;
+
+  // While we still haven't found it to be a subclass of Krypton.Model
+  // AND it has a super class.
+  while (!isSubclass && currentModel.superClass !== null) {
+    // If we find it to be a subclass of Krypton.Model
+    if (currentModel.superClass.className === superName) {
+      isSubclass = true;
+    } else {
+      currentModel = currentModel.superClass;
+    }
+  }
+
+  return isSubclass;
+};
+
 Krypton.Relation = Class(Krypton, 'Relation')({
   prototype : {
     name : null,
@@ -15,8 +34,16 @@ Krypton.Relation = Class(Krypton, 'Relation')({
         throw new Error('Must provide an ownerModel');
       }
 
+      if (!loopThroughSuper(config.ownerModel)) {
+        throw new Error('ownerModel is not (eventually) a subclass of Krypton.Model');
+      }
+
       if (!config.relatedModel) {
         throw new Error('Must provide a relatedModel');
+      }
+
+      if (!loopThroughSuper(config.relatedModel)) {
+        throw new Error('relatedModel is not (eventually) a subclass of Krypton.Model');
       }
 
       if (!config.ownerCol || !_.isString(config.ownerCol)) {

--- a/krypton/Relation.js
+++ b/krypton/Relation.js
@@ -8,13 +8,6 @@ Krypton.Relation = Class(Krypton, 'Relation')({
     ownerCol : null,
     relatedCol : null,
     scope : null,
-    /*
-    through : {
-      tableName : null,
-      ownerCol : null,
-      relatedCol : null,
-      scope : null
-    } */
     through : null,
 
     init : function(config) {
@@ -22,16 +15,8 @@ Krypton.Relation = Class(Krypton, 'Relation')({
         throw new Error('Must provide an ownerModel');
       }
 
-      if (config.ownerModel.superClass.className !== Krypton.Model.className) {
-        throw new Error('ownerModel is not a subclass of Krypton.Model');
-      }
-
       if (!config.relatedModel) {
         throw new Error('Must provide a relatedModel');
-      }
-
-      if (config.relatedModel.superClass.className !== Krypton.Model.className) {
-        throw new Error('relatedModel is not a subclass of Krypton.Model');
       }
 
       if (!config.ownerCol || !_.isString(config.ownerCol)) {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Krypton is a full featured Javascript ORM for SQL Databases",
   "main": "index.js",
   "scripts": {
-    "test": "istanbul cover _mocha -- --slow 10 --timeout 5000 --reporter spec --recursive tests"
+    "test": "NODE_ENV=test istanbul cover _mocha -- --slow 10 --timeout 5000 --reporter spec --recursive tests"
   },
   "repository": {
     "type": "git",
@@ -39,10 +39,10 @@
   "devDependencies": {
     "chai": "^3.3.0",
     "codeclimate-test-reporter": "^0.3.1",
-    "istanbul": "^0.4.2",
+    "istanbul": "0.4.2",
     "knex": "^0.9.0",
     "mocha": "^2.3.3",
-    "pg": "^4.4.3",
-    "mysql": "^2.10.0"
+    "mysql": "^2.10.0",
+    "pg": "^4.4.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "krypton-orm",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "Krypton is a full featured Javascript ORM for SQL Databases",
   "main": "index.js",
   "scripts": {

--- a/tests/unit/Krypton.Relation.js
+++ b/tests/unit/Krypton.Relation.js
@@ -57,10 +57,36 @@ describe('Krypton.Relation', function() {
     expect(relation).to.throw(Error);
   });
 
+  it('Should fail if ownerModel is not a subclass of Krypton.Model', function() {
+    var relation = function() {
+      return new Krypton.Relation({
+        ownerModel : Class('Model')({}),
+        relatedModel : RelatedModel,
+        ownerCol : 'related_col_id',
+        relatedCol : 'id'
+      });
+    }
+
+    expect(relation).to.throw(Error);
+  });
+
   it('Should fail if relatedModel is missing', function() {
     var relation = function() {
       return new Krypton.Relation({
         ownerModel : OwnerModel,
+        ownerCol : 'related_col_id',
+        relatedCol : 'id'
+      });
+    }
+
+    expect(relation).to.throw(Error);
+  });
+
+  it('Should fail if relatedModel is not a subclass of Krypton.Model', function() {
+    var relation = function() {
+      return new Krypton.Relation({
+        ownerModel : OwnerModel,
+        relatedModel : Class('Model')({}),
         ownerCol : 'related_col_id',
         relatedCol : 'id'
       });

--- a/tests/unit/Krypton.Relation.js
+++ b/tests/unit/Krypton.Relation.js
@@ -57,36 +57,10 @@ describe('Krypton.Relation', function() {
     expect(relation).to.throw(Error);
   });
 
-  it('Should fail if ownerModel is not a subclass of Krypton.Model', function() {
-    var relation = function() {
-      return new Krypton.Relation({
-        ownerModel : Class('Model')({}),
-        relatedModel : RelatedModel,
-        ownerCol : 'related_col_id',
-        relatedCol : 'id'
-      });
-    }
-
-    expect(relation).to.throw(Error);
-  });
-
   it('Should fail if relatedModel is missing', function() {
     var relation = function() {
       return new Krypton.Relation({
         ownerModel : OwnerModel,
-        ownerCol : 'related_col_id',
-        relatedCol : 'id'
-      });
-    }
-
-    expect(relation).to.throw(Error);
-  });
-
-  it('Should fail if relatedModel is not a subclass of Krypton.Model', function() {
-    var relation = function() {
-      return new Krypton.Relation({
-        ownerModel : OwnerModel,
-        relatedModel : Class('Model')({}),
         ownerCol : 'related_col_id',
         relatedCol : 'id'
       });

--- a/tests/unit/Krypton.Relation.js
+++ b/tests/unit/Krypton.Relation.js
@@ -70,6 +70,21 @@ describe('Krypton.Relation', function() {
     expect(relation).to.throw(Error);
   });
 
+  it('Should not fail if ownerModel is (eventually) a subclass of Krypton.Model', function() {
+    var ParentClass = Class('ParentClass').inherits(Krypton.Model)({});
+
+    var relation = function() {
+      return new Krypton.Relation({
+        ownerModel : Class('Model').inherits(ParentClass)({}),
+        relatedModel : RelatedModel,
+        ownerCol : 'related_col_id',
+        relatedCol : 'id'
+      });
+    }
+
+    expect(relation).to.not.throw(Error);
+  });
+
   it('Should fail if relatedModel is missing', function() {
     var relation = function() {
       return new Krypton.Relation({
@@ -80,6 +95,21 @@ describe('Krypton.Relation', function() {
     }
 
     expect(relation).to.throw(Error);
+  });
+
+  it('Should not fail if relatedModel is (eventually) a subclass of Krypton.Model', function() {
+    var ParentClass = Class('ParentClass').inherits(Krypton.Model)({});
+
+    var relation = function() {
+      return new Krypton.Relation({
+        ownerModel : OwnerModel,
+        relatedModel : Class('Model').inherits(ParentClass)({}),
+        ownerCol : 'related_col_id',
+        relatedCol : 'id'
+      });
+    }
+
+    expect(relation).to.not.throw(Error);
   });
 
   it('Should fail if relatedModel is not a subclass of Krypton.Model', function() {


### PR DESCRIPTION
This was causing trouble in one of our projects where we don't inherit directly from `Krypton.Model` and rather we inherit from a class that inherits from `Krypton.Model`.