### PR TITLE
Sugar and fixes

### DIFF
--- a/krypton/Model.js
+++ b/krypton/Model.js
@@ -22,7 +22,11 @@ Krypton.Model = Class(Krypton, 'Model').includes(Krypton.ValidationSupport)({
 
   _relations : {},
 
-  preprocessors : [
+  // instances should override this arrays instead
+  preprocessors : [],
+  processors : [],
+
+  _preprocessors : [
     function(data) { // snakeCase-ise (to DB)
       var sanitizedData;
       var property;
@@ -39,7 +43,7 @@ Krypton.Model = Class(Krypton, 'Model').includes(Krypton.ValidationSupport)({
     }
   ],
 
-  processors : [
+  _processors : [
     function(data) { // camelCase-ise (from DB)
       var sanitizedData = [];
 
@@ -262,9 +266,10 @@ Krypton.Model = Class(Krypton, 'Model').includes(Krypton.ValidationSupport)({
                 .then(function () {
                   var values = model._getAttributes();
 
-                  for (var i = 0; i < model.constructor.preprocessors.length; i++) {
-                    values = model.constructor.preprocessors[i](values);
-                  }
+                  (model.constructor._preprocessors.concat(model.constructor.preprocessors))
+                    .forEach(function (proc) {
+                      values = proc.call(model, values);
+                    });
 
                   return model._create(values);
                 })
@@ -288,9 +293,10 @@ Krypton.Model = Class(Krypton, 'Model').includes(Krypton.ValidationSupport)({
                 .then(function () {
                   var values = model._getAttributes();
 
-                  for (var i = 0; i < model.constructor.preprocessors.length; i++) {
-                    values = model.constructor.preprocessors[i](values);
-                  }
+                  (model.constructor._preprocessors.concat(model.constructor.preprocessors))
+                    .forEach(function (proc) {
+                      values = proc.call(model, values);
+                    });
 
                   return model._update(values);
                 })

--- a/krypton/Model.js
+++ b/krypton/Model.js
@@ -103,12 +103,7 @@ Krypton.Model = Class(Krypton, 'Model').includes(Krypton.ValidationSupport)({
   },
 
   update : function (props, data) {
-    return this._query(props).then(function (results) {
-      return Promise.all(results.map(function (row) {
-        row.updateAttributes(data);
-        return row.save();
-      }));
-    });
+    return this._query(props).update(data);
   },
 
   first : function(props) {

--- a/krypton/Model.js
+++ b/krypton/Model.js
@@ -75,6 +75,47 @@ Krypton.Model = Class(Krypton, 'Model').includes(Krypton.ValidationSupport)({
 
   attributes : [],
 
+  // convenience methods
+  _query: function (idOrWhere) {
+    var query = this.query();
+
+    if (typeof idOrWhere === 'object') {
+      if (Array.isArray(idOrWhere)) {
+        query.whereIn(this.primaryKey, idOrWhere);
+      } else {
+        query.where(idOrWhere);
+      }
+    }
+
+    if (typeof idOrWhere === 'string' || typeof idOrWhere === 'number') {
+      query.where(this.primaryKey, idOrWhere);
+    }
+
+    return query;
+  },
+
+  destroy : function (props) {
+    return this._query(props).then(function (results) {
+      return Promise.all(results.map(function (row) {
+        return row.destroy();
+      }));
+    });
+  },
+
+  update : function (props, data) {
+    return this._query(props).then(function (results) {
+      return Promise.all(results.map(function (row) {
+        row.updateAttributes(data);
+        return row.save();
+      }));
+    });
+  },
+
+  first : function(props) {
+    return this._query(props).then(function (results) {
+      return results[0];
+    });
+  },
 
   query : function(knex) {
     if (!this.tableName) {

--- a/krypton/Model.js
+++ b/krypton/Model.js
@@ -98,12 +98,8 @@ Krypton.Model = Class(Krypton, 'Model').includes(Krypton.ValidationSupport)({
     return query;
   },
 
-  destroy : function (props) {
-    return this._query(props).then(function (results) {
-      return Promise.all(results.map(function (row) {
-        return row.destroy();
-      }));
-    });
+  delete : function (props) {
+    return this._query(props).delete();
   },
 
   update : function (props, data) {

--- a/krypton/QueryBuilder.js
+++ b/krypton/QueryBuilder.js
@@ -60,9 +60,10 @@ Krypton.QueryBuilder = Class(Krypton, 'QueryBuilder').includes(Krypton.Knex)({
       });
 
       if (methodCallNames.indexOf('pluck') === -1) {
-        for (var i = 0; i < builder.ownerModel.processors.length; i++) {
-          records = builder.ownerModel.processors[i](records);
-        }
+        (builder.ownerModel._processors.concat(builder.ownerModel.processors))
+          .forEach(function (proc) {
+            records = proc(records, builder.ownerModel);
+          });
 
         if (records.length > 0 && _.isObject(records[0])) {
           for (var i = 0, l = records.length; i < l; ++i) {


### PR DESCRIPTION
With this changes we're now able to:

1) Extends freely from `Krypton.Model` without worrying about `preprocessors` and `processors` being replaced on each new class definition.

``` js
var User = Class('User').inherits(Krypton.Model)({
  tableName: 'Users',
  preprocessors: [function (data) {
    return data;
  }],
});
```

2) Adds some static methods as shortcuts: `Model.first()`, `Model.update()` and `Model.delete()` where each of this methods can receive a single value, an array of values or an object as where props.

``` js
Model.first(13) // Model.query().where({ id: 13 })
Model.delete([1, 2, 3]) // Model.query().whereIn('id', [1, 2, 3])
Model.update({ foo: 'bar' }, { baz: 'buzz' }) // Model.query().where({ foo: 'bar' }).update({ baz: 'buzz' })
```
